### PR TITLE
Fix: Correct translator type hint in RESTProductLazyArray

### DIFF
--- a/classes/RESTProductLazyArray.php
+++ b/classes/RESTProductLazyArray.php
@@ -14,7 +14,7 @@ use PrestaShop\Decimal\Operation\Rounding;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
-use Symfony\Component\Translation\TranslatorInterface;
+use PrestaShopBundle\Translation\TranslatorComponent;
 
 class RESTProductLazyArray
 {
@@ -44,7 +44,7 @@ class RESTProductLazyArray
     private $imageRetriever;
 
     /**
-     * @var TranslatorInterface
+     * @var TranslatorComponent
      */
     private $translator;
 
@@ -54,7 +54,7 @@ class RESTProductLazyArray
         Language $language,
         PriceFormatter $priceFormatter,
         ImageRetriever $imageRetriever,
-        TranslatorInterface $translator
+        TranslatorComponent $translator
     ) {
         $this->settings = $settings;
         $this->product = $product;


### PR DESCRIPTION
Updated the type hint for the $translator parameter in the RESTProductLazyArray constructor, its property declaration, and the corresponding 'use' statement.

Changed from Symfony\Component\Translation\TranslatorInterface to PrestaShopBundle\Translation\TranslatorComponent to match the actual type being passed from the controller, resolving a TypeError.